### PR TITLE
Allow double assume to allow for connector role and client role

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -19,6 +19,7 @@ package io.confluent.connect.s3.auth;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -35,7 +36,9 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
 
   public static final String ROLE_EXTERNAL_ID_CONFIG = "sts.role.external.id";
   public static final String ROLE_ARN_CONFIG = "sts.role.arn";
+  public static final String BASE_ROLE_ARN_CONFIG = "sts.base.role.arn";
   public static final String ROLE_SESSION_NAME_CONFIG = "sts.role.session.name";
+  public static final String BASE_ROLE_SESSION_NAME_CONFIG = "sts.base.session.name";
 
   private static final ConfigDef STS_CONFIG_DEF = new ConfigDef()
       .define(
@@ -53,11 +56,23 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
           ConfigDef.Type.STRING,
           ConfigDef.Importance.HIGH,
           "Role session name to use when starting a session"
+      ).define(
+          BASE_ROLE_SESSION_NAME_CONFIG,
+          ConfigDef.Type.STRING,
+          ConfigDef.Importance.HIGH,
+          "Base Role session name to use when starting a session"
+      ).define(
+          BASE_ROLE_ARN_CONFIG,
+          ConfigDef.Type.STRING,
+          ConfigDef.Importance.HIGH,
+          "Base Role ARN to use when starting a session"
       );
 
+  private String baseRoleArn;
   private String roleArn;
   private String roleExternalId;
   private String roleSessionName;
+  private String baseRoleSessionName;
 
   @Override
   public void configure(Map<String, ?> configs) {
@@ -65,15 +80,28 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
     roleArn = config.getString(ROLE_ARN_CONFIG);
     roleExternalId = config.getString(ROLE_EXTERNAL_ID_CONFIG);
     roleSessionName = config.getString(ROLE_SESSION_NAME_CONFIG);
+    baseRoleArn = config.getString(BASE_ROLE_ARN_CONFIG);
+    baseRoleSessionName = config.getString(BASE_ROLE_SESSION_NAME_CONFIG);
   }
 
   @Override
   public AWSCredentials getCredentials() {
     return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
-        .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
+        .withStsClient(getBaseSecurityTokenService())
         .withExternalId(roleExternalId)
         .build()
         .getCredentials();
+  }
+
+  public AWSSecurityTokenService getBaseSecurityTokenService() {
+    if (this.baseRoleArn != null && !this.baseRoleArn.isEmpty()) {
+      AWSCredentialsProvider baseCredentials = new STSAssumeRoleSessionCredentialsProvider.Builder(baseRoleArn, baseRoleSessionName)
+              .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
+              .build();
+      return AWSSecurityTokenServiceClientBuilder.standard().withCredentials(baseCredentials).build();
+    } else {
+      return AWSSecurityTokenServiceClientBuilder.defaultClient();
+    }
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -59,12 +59,14 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
       ).define(
           BASE_ROLE_SESSION_NAME_CONFIG,
           ConfigDef.Type.STRING,
-          ConfigDef.Importance.HIGH,
+          "",
+          ConfigDef.Importance.MEDIUM,
           "Base Role session name to use when starting a session"
       ).define(
           BASE_ROLE_ARN_CONFIG,
           ConfigDef.Type.STRING,
-          ConfigDef.Importance.HIGH,
+          "",
+          ConfigDef.Importance.MEDIUM,
           "Base Role ARN to use when starting a session"
       );
 
@@ -95,10 +97,12 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
 
   public AWSSecurityTokenService getBaseSecurityTokenService() {
     if (this.baseRoleArn != null && !this.baseRoleArn.isEmpty()) {
-      AWSCredentialsProvider baseCredentials = new STSAssumeRoleSessionCredentialsProvider.Builder(baseRoleArn, baseRoleSessionName)
-              .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
-              .build();
-      return AWSSecurityTokenServiceClientBuilder.standard().withCredentials(baseCredentials).build();
+      AWSCredentialsProvider baseCredentials =
+              new STSAssumeRoleSessionCredentialsProvider.Builder(baseRoleArn, baseRoleSessionName)
+                .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
+                .build();
+      return AWSSecurityTokenServiceClientBuilder.standard()
+              .withCredentials(baseCredentials).build();
     } else {
       return AWSSecurityTokenServiceClientBuilder.defaultClient();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Problem

We want to have connector running by default under a different role than the whole Kafka Connect setup and different role than clients. This requires introduction of another parameter allowing "double" assume.

## Solution
Double assume added.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
